### PR TITLE
Fix dragon enemy not dying to buffed knight

### DIFF
--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -60,6 +60,7 @@ MonoBehaviour:
   - RPC_UpdatePartnerIndicator
   - RPC_RemovePartnerIndicator
   - RPC_ApplyBuff
+  - RPC_HandleAttackHit
   DisableAutoOpenWizard: 1
   ShowSettings: 0
   DevRegionSetOnce: 1

--- a/Assets/Resources/Dragon Enemy Ranged.prefab
+++ b/Assets/Resources/Dragon Enemy Ranged.prefab
@@ -585,9 +585,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7c23f934294204f4ea421e5cf0526e36, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  photonView: {fileID: 2580839893817942634}
   collider2d: {fileID: 2580839893422323836}
   rigidbody2d: {fileID: 2580839893817942640}
   animator: {fileID: 8790055526326636033}
+  movement: {fileID: 2580839893817942633}
   attackEffectLayer:
     serializedVersion: 2
     m_Bits: 256

--- a/Assets/Resources/Dragon Enemy.prefab
+++ b/Assets/Resources/Dragon Enemy.prefab
@@ -444,9 +444,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7c23f934294204f4ea421e5cf0526e36, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  photonView: {fileID: 6640825776839568949}
   collider2d: {fileID: 6758016192082639341}
   rigidbody2d: {fileID: 6640825776839569096}
   animator: {fileID: 5540462038900781736}
+  movement: {fileID: 6640825776839569099}
   attackEffectLayer:
     serializedVersion: 2
     m_Bits: 256
@@ -454,6 +456,7 @@ MonoBehaviour:
   - abilityIdentifier: 0
     ability: {fileID: 458767237906566525}
   health: {fileID: 5584288266804474021}
+  buff: {fileID: 0}
   wallCollisionDetector: {fileID: 8923394087307039422}
   knockbackSpeed: 0
   knockbackDistance: 0

--- a/Assets/Resources/Dragon.prefab
+++ b/Assets/Resources/Dragon.prefab
@@ -190,9 +190,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7c23f934294204f4ea421e5cf0526e36, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  photonView: {fileID: 4470413134207635888}
   collider2d: {fileID: 6525134411238163316}
   rigidbody2d: {fileID: 4470413134207635895}
   animator: {fileID: 3806877152634518949}
+  movement: {fileID: 4470413134207635889}
   attackEffectLayer:
     serializedVersion: 2
     m_Bits: 1024

--- a/Assets/Resources/Knight Enemy Ranged.prefab
+++ b/Assets/Resources/Knight Enemy Ranged.prefab
@@ -520,9 +520,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7c23f934294204f4ea421e5cf0526e36, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  photonView: {fileID: 2315394145704112158}
   collider2d: {fileID: 3812630226607940506}
   rigidbody2d: {fileID: 9072196668915215803}
   animator: {fileID: 271088900839404577}
+  movement: {fileID: 2080431000792514480}
   attackEffectLayer:
     serializedVersion: 2
     m_Bits: 128
@@ -530,6 +532,7 @@ MonoBehaviour:
   - abilityIdentifier: 1
     ability: {fileID: 7085852033703407569}
   health: {fileID: 4948305080866607028}
+  buff: {fileID: 0}
   wallCollisionDetector: {fileID: 276739738191126824}
   knockbackSpeed: 0
   knockbackDistance: 0

--- a/Assets/Resources/Knight Enemy.prefab
+++ b/Assets/Resources/Knight Enemy.prefab
@@ -377,9 +377,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7c23f934294204f4ea421e5cf0526e36, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  photonView: {fileID: 5693331145748344914}
   collider2d: {fileID: 8342237615520396707}
   rigidbody2d: {fileID: 5693331145748344916}
   animator: {fileID: 3091961783657160481}
+  movement: {fileID: 5693331145748344913}
   attackEffectLayer:
     serializedVersion: 2
     m_Bits: 128
@@ -387,6 +389,7 @@ MonoBehaviour:
   - abilityIdentifier: 0
     ability: {fileID: 1707262774369454606}
   health: {fileID: 707785210333968309}
+  buff: {fileID: 0}
   wallCollisionDetector: {fileID: 3776096321984719771}
   knockbackSpeed: 10
   knockbackDistance: 1.2

--- a/Assets/Resources/Knight.prefab
+++ b/Assets/Resources/Knight.prefab
@@ -444,9 +444,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7c23f934294204f4ea421e5cf0526e36, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  photonView: {fileID: 5696632616774609759}
   collider2d: {fileID: 5003391959657003033}
   rigidbody2d: {fileID: 5696632616774609753}
   animator: {fileID: 977637900953337948}
+  movement: {fileID: 6669902685249964190}
   attackEffectLayer:
     serializedVersion: 2
     m_Bits: 1024

--- a/Assets/Scripts/State Machine/States/Combat States/Attack States/MeleeAttackState.cs
+++ b/Assets/Scripts/State Machine/States/Combat States/Attack States/MeleeAttackState.cs
@@ -26,15 +26,7 @@ namespace CombatStates
                 ActorController actorHit = ActorController.GetActorFromCollider(hit);
                 if (actorHit != null)
                 {
-                    actorHit.Movement.UpdateMovement(Vector2.zero);
-                    if (actorHit.Combat.CombatStateMachine.CurrState is BlockState blockState)
-                    {
-                        blockState.HandleHit(actorHit.Movement.IsFacingRight, (actorHit.transform.position - owner.transform.position).normalized);
-                    }
-                    else
-                    {
-                        actorHit.Combat.Hurt();
-                    }
+                    actorHit.Combat.HandleAttackHit(owner);
                 }
             }
         }


### PR DESCRIPTION
The buffed knight's attack did not kill the dragon enemy over the network, resulting in the dragon enemy continuing to live despite "dying" on the knight's client. This has been fixed.

Let's
- add `Movement` and `PhotonView` serialized fields to `Combat` component
- move handling of an attack's hit to a `HandleAttackHit` method in the `Combat` class
- either handle the hit locally in `LocalHandleAttackHit` or allow network owner to handle it using RPC